### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.aqovia.com


### PR DESCRIPTION
aqovia.com DNS records no longer point to Github, so removing the CNAME to prevent to re-enable access to all other GitHub pages in the Aqovia org.